### PR TITLE
Fix apparently stuck tasks

### DIFF
--- a/src/genomon_api/executor/genomon_pipeline_cloud.clj
+++ b/src/genomon_api/executor/genomon_pipeline_cloud.clj
@@ -36,7 +36,7 @@
 
 (defn- parse-log [{{:keys [body]} :log :as event}]
   (condp re-matches body
-    #".*ecsub submit .*--tasks \S+?([^/\s]+)-tasks.*\n"
+    #".*aws ecs register-task-definition .*--cli-input-json \S+/(\S+)-tasks-.*\n"
     :>> (fn [[_ x]]
           {:task (keyword x),
            :status :submitted})


### PR DESCRIPTION
I've run into an unexpected situation several times, where the status of a Genomon task, which is managed in the executor, remained to be `submitted` even after the whole `genomon_pipeline_cloud` process had finished. I figured out an execution path that prevents `genomon-api` from detecting correct status transitions.

Currently, `genomon-api` recognizes the start and end of a Genomon task by detecting logs in specific patterns. The task start is detected by [the logs for task submission via `ecsub`](https://github.com/chrovis/genomon-api/blob/f4a5ae627d1efbd87ca81745142a6fc85ffb20d5/src/genomon_api/executor/genomon_pipeline_cloud.clj#L39) while the end is detected by [the logs for the command `aws ecs deregister-task-definition`](https://github.com/chrovis/genomon-api/blob/f4a5ae627d1efbd87ca81745142a6fc85ffb20d5/src/genomon_api/executor/genomon_pipeline_cloud.clj#L43). However, `ecsub` may exit without doing anything before submitting a task to AWS ECS, especially when [`ecsub` is called with an empty task file (tsv)](https://github.com/alumi/ecsub/blob/d62470746c96e04fb7eb4a7411c5c3f65d0e7aa9/scripts/ecsub/submit.py#L601-L603). In this case, the task will remain to be `submitted` since the task submission via `ecsub` will be successfully detected, but the corresponding command `aws ecs deregister-task-definition` will never be emitted.

`genomon-api` calls `ecsub` for the `sv-merge` task [with an empty task file](https://github.com/chrovis/genomon_pipeline_cloud/blob/7a54effc6c6264a28a8cf72494f8b356cfd24589/genomon_pipeline_cloud/tasks/sv_merge.py#L20) unless a specific control panel is configured, and which eventually causes the DNA pipeline to fail when executed without a control panel.

I think it's more reliable to detect a task start with the command logs which can be considered as a direct evidence indicating that the task was actually executed, such as [`aws ecs register-task-definition`](https://github.com/alumi/ecsub/blob/d62470746c96e04fb7eb4a7411c5c3f65d0e7aa9/scripts/ecsub/aws.py#L484) or [`aws ecs create-cluster`](https://github.com/alumi/ecsub/blob/d62470746c96e04fb7eb4a7411c5c3f65d0e7aa9/scripts/ecsub/aws.py#L350). Here, the PR suggested the command `aws ecs register-task-definition`, but I'm not really sure if that is the best option to choose, so you may want to think of my patch just as a rough draft to discuss the issue further.