### PR TITLE
Don't throw even if some subtasks are eventually unfinished

### DIFF
--- a/src/genomon_api/executor/genomon_pipeline_cloud.clj
+++ b/src/genomon_api/executor/genomon_pipeline_cloud.clj
@@ -63,7 +63,7 @@
                      (throw (ex-info "Results not found" {})))
                    (map-leaves (partial storage/stat storage) results)
                    (when-not (every? #{:terminated :skipped} (vals @state))
-                     (throw (ex-info "Tasks not finished" @state)))
+                     (log/warn logger ::incomplete-sub-tasks @state))
                    (assoc run-event :sub-tasks @state)
                    (catch Throwable e
                      (assoc run-event :status :failed :error e)))


### PR DESCRIPTION
While #1 has not been resolved yet and it may take us a little more time to resolve it, we already know that the issue is about the status management for subtasks. On the other hand, we don't actually need such a strict status check at the moment, just for running Genomon pipelines.

This PR temporarily makes the status check more relaxed so that incomplete subtasks will not cause to disrupt the execution, and just emits a log that some subtasks were unfinished.