### PR TITLE
tumor-only analysis for DNA pipeline

### DIFF
--- a/resources/migrations/002-init-dna-runs.up.sql
+++ b/resources/migrations/002-init-dna-runs.up.sql
@@ -1,8 +1,8 @@
 CREATE TABLE `dna-runs` (
   `dna-run-id` INT UNSIGNED AUTO_INCREMENT NOT NULL,
   `run-id` BINARY(16) NOT NULL,
-  `normal-r1` VARCHAR(1024) NOT NULL,
-  `normal-r2` VARCHAR(1024) NOT NULL,
+  `normal-r1` VARCHAR(1024) DEFAULT NULL,
+  `normal-r2` VARCHAR(1024) DEFAULT NULL,
   `tumor-r1` VARCHAR(1024) NOT NULL,
   `tumor-r2` VARCHAR(1024) NOT NULL,
   `normal-bam` VARCHAR(1024) DEFAULT NULL,

--- a/src/genomon_api/db/worker.clj
+++ b/src/genomon_api/db/worker.clj
@@ -33,6 +33,6 @@
             :dna (db/update-dna-run-status db m)
             :rna (db/update-rna-run-status db m))
           (catch Throwable e
-            (log/error logger ::error m)))
+            (log/error logger ::error (assoc m :error e))))
         (recur))
       (log/debug logger ::end-worker {}))))

--- a/src/genomon_api/util/csv.clj
+++ b/src/genomon_api/util/csv.clj
@@ -11,12 +11,16 @@
 
 (defn gen-dna-input [{{normal-r1 :r1 normal-r2 :r2} :normal
                       {tumor-r1 :r1 tumor-r2 :r2} :tumor}]
-  (gen-input-file [[:fastq [["tumor" tumor-r1 tumor-r2]
-                            ["normal" normal-r1 normal-r2]]]
-                   [:mutation-call [["tumor" "normal" "None"]]]
-                   [:sv-detection [["tumor" "normal" "None"]]]
-                   [:qc [["tumor"]
-                         ["normal"]]]]))
+  (if (and normal-r1 normal-r2)
+    (gen-input-file [[:fastq [["tumor" tumor-r1 tumor-r2]
+                              ["normal" normal-r1 normal-r2]]]
+                     [:mutation-call [["tumor" "normal" "None"]]]
+                     [:sv-detection [["tumor" "normal" "None"]]]
+                     [:qc [["tumor"] ["normal"]]]])
+    (gen-input-file [[:fastq [["tumor" tumor-r1 tumor-r2]]]
+                     [:mutation-call [["tumor" "None" "None"]]]
+                     [:sv-detection [["tumor" "None" "None"]]]
+                     [:qc [["tumor"]]]])))
 
 (defn gen-rna-input [{:keys [r1 r2]}]
   (gen-input-file [[:fastq [["rna" r1 r2]]]

--- a/test/src/genomon_api/db/sql_test.clj
+++ b/test/src/genomon_api/db/sql_test.clj
@@ -21,43 +21,75 @@
                                   :genomon-api.executor.genomon-pipeline-cloud.config/dna])
   db-fixture)
 
-(def ^:const dna-run-id #uuid "bd067680-2670-4b3d-8564-5025ce2b3cc1")
+(def ^:const dna-run-id1 #uuid "bd067680-2670-4b3d-8564-5025ce2b3cc1")
+(def ^:const dna-run-id2 #uuid "dc2a3897-6b1d-49e5-b506-da33ce1ec8f9")
 (def ^:const rna-run-id #uuid "883ef3e4-caac-49aa-b956-960856aa632c")
 (def ^:const image-id "sha256:bba9d76fd02ee2344ffe807c1aaa4d20171196d6d2f26b46479bb727f4b79b8c")
 (def ^:const container-id "d97405db841d5bc685c2079d188ac829119cca142d1154545a69374ce5acc237")
 
 (deftest db-test
   (testing "dna-runs"
-    (is (nil? (db/get-dna-run *db* {:run-id dna-run-id})))
-    (is (not (nil? (db/create-dna-run *db* {:run-id dna-run-id,
+    (is (nil? (db/get-dna-run *db* {:run-id dna-run-id1})))
+    (is (not (nil? (db/create-dna-run *db* {:run-id dna-run-id1,
                                             :status :created,
                                             :samples {:normal {:r1 "nr1", :r2 "nr2"},
                                                       :tumor {:r1 "tr1", :r2 "tr2"}},
-                                            :output-dir (str "s3://genomon-api/test/" dna-run-id),
+                                            :output-dir (str "s3://genomon-api/test/" dna-run-id1),
                                             :image-id image-id,
                                             :container-id container-id,
                                             :config {}}))))
-    (is (= {:run-id dna-run-id,
+    (is (= {:run-id dna-run-id1,
             :status :created,
             :samples {:normal {:r1 "nr1", :r2 "nr2"},
                       :tumor {:r1 "tr1", :r2 "tr2"}},
-            :output-dir (str "s3://genomon-api/test/" dna-run-id),
+            :output-dir (str "s3://genomon-api/test/" dna-run-id1),
             :image-id image-id,
             :container-id container-id,
             :config {},
             :results {:normal-bam nil, :tumor-bam nil, :svs nil, :mutations nil}}
-           (dissoc (db/get-dna-run *db* {:run-id dna-run-id}) :created-at :updated-at)))
+           (dissoc (db/get-dna-run *db* {:run-id dna-run-id1}) :created-at :updated-at)))
     (is (not (nil? (seq (db/list-dna-runs *db* {:limit 10 :offset 0})))))
-    (is (nil? (db/update-dna-run-status *db* {:run-id dna-run-id,
+    (is (nil? (db/update-dna-run-status *db* {:run-id dna-run-id1,
                                               :status :started})))
-    (is (= 1 (db/update-dna-run-status *db* {:run-id dna-run-id,
+    (is (= 1 (db/update-dna-run-status *db* {:run-id dna-run-id1,
                                              :status :succeeded,
                                              :results {:normal-bam ""
                                                        :tumor-bam ""
                                                        :svs ""
                                                        :mutations ""}})))
-    (is (= 1 (db/delete-dna-run *db* {:run-id dna-run-id})))
-    (is (nil? (db/get-dna-run *db* {:run-id dna-run-id}))))
+    (is (= 1 (db/delete-dna-run *db* {:run-id dna-run-id1})))
+    (is (nil? (db/get-dna-run *db* {:run-id dna-run-id1}))))
+  (testing "dna-runs without normal sample"
+    (is (nil? (db/get-dna-run *db* {:run-id dna-run-id2})))
+    (is (not (nil? (db/create-dna-run *db* {:run-id dna-run-id2,
+                                            :status :created,
+                                            :samples {:normal {:r1 nil, :r2 nil},
+                                                      :tumor {:r1 "tr1", :r2 "tr2"}},
+                                            :output-dir (str "s3://genomon-api/test/" dna-run-id2),
+                                            :image-id image-id,
+                                            :container-id container-id,
+                                            :config {}}))))
+    (is (= {:run-id dna-run-id2,
+            :status :created,
+            :samples {:normal {:r1 nil, :r2 nil},
+                      :tumor {:r1 "tr1", :r2 "tr2"}},
+            :output-dir (str "s3://genomon-api/test/" dna-run-id2),
+            :image-id image-id,
+            :container-id container-id,
+            :config {},
+            :results {:normal-bam nil, :tumor-bam nil, :svs nil, :mutations nil}}
+           (dissoc (db/get-dna-run *db* {:run-id dna-run-id2}) :created-at :updated-at)))
+    (is (not (nil? (seq (db/list-dna-runs *db* {:limit 10 :offset 0})))))
+    (is (nil? (db/update-dna-run-status *db* {:run-id dna-run-id2,
+                                              :status :started})))
+    (is (= 1 (db/update-dna-run-status *db* {:run-id dna-run-id2,
+                                             :status :succeeded,
+                                             :results {:normal-bam nil
+                                                       :tumor-bam ""
+                                                       :svs ""
+                                                       :mutations ""}})))
+    (is (= 1 (db/delete-dna-run *db* {:run-id dna-run-id2})))
+    (is (nil? (db/get-dna-run *db* {:run-id dna-run-id2}))))
   (testing "rna-runs"
     (is (nil? (db/get-rna-run *db* {:run-id rna-run-id})))
     (is (not (nil? (db/create-rna-run *db* {:run-id rna-run-id,


### PR DESCRIPTION
`genomon_pipeline_cloud` has a feature that performs tumor-only analysis for DNA pipeline while `genomon-api` doesn't support it for now and always requires a pair of normal/tumor samples.

This PR allows `genomon-api` to accept requests with only a tumor sample to enable tumor-only analysis for DNA pipeline.

Note that this change directly overwrites an existing table definition instead of adding some migrations, so you may need to drop the table or update its schema accordingly in your environment if you want to see how it actually works.