### PR TITLE
Support for sv-in-rna

### DIFF
--- a/resources/genomon_api/rna_param.edn
+++ b/resources/genomon_api/rna_param.edn
@@ -1,4 +1,27 @@
-{:star-alignment
+{:bwa-alignment
+ {:resource "--aws-ec2-instance-type t2.2xlarge --disk-size 80",
+  :image "genomon/bwa_alignment:0.2.0",
+  :bamtofastq-option "collate=1 combs=1 exclude=QCFAIL,SECONDARY,SUPPLEMENTARY tryoq=1",
+  :bwa-option "-t 8 -T 0",
+  :bwa-reference-dir "s3://genomon-bucket-xcoo-archive-202001/_GRCh37/reference/GRCh37",
+  :bwa-reference-file "GRCh37.fa",
+  :bamsort-option "index=1 level=1 inputthreads=2 outputthreads=2 calmdnm=1 calmdnmrecompindentonly=1",
+  :bammarkduplicates-option "markthreads=2 rewritebam=1 rewritebamlevel=1 index=1 md5=1"},
+ :sv-parse
+ {:resource "--aws-ec2-instance-type t2.large --disk-size 15",
+  :image "genomon/genomon_sv:0.1.0",
+  :genomon-sv-parse-option ""},
+ :sv-merge
+ {:resource "--aws-ec2-instance-type t2.large --disk-size 15",
+  :image "genomon/genomon_sv:0.1.0",
+  :genomon-sv-merge-option ""},
+ :sv-filt
+ {:resource "--aws-ec2-instance-type t2.large --disk-size 50",
+  :image "genomon/genomon_sv:0.1.0",
+  :reference "s3://genomon-bucket-xcoo-archive-202001/_GRCh37/reference/GRCh37/GRCh37.fa",
+  :genomon-sv-filt-option "--grc --min_junc_num 2 --max_control_variant_read_pair 10 --min_overhang_size 30",
+  :sv-utils-filt-option "--min_tumor_allele_freq 0.07 --max_control_variant_read_pair 1 --control_depth_thres 10 --inversion_size_thres 1000"},
+ :star-alignment
  {:resource "--aws-ec2-instance-type t2.2xlarge --disk-size 128",
   :image "genomon/star_alignment",
   :bamtofastq-option "collate=1 combs=1 exclude=QCFAIL,SECONDARY,SUPPLEMENTARY tryoq=1",

--- a/resources/hugsql/rna_runs.sql
+++ b/resources/hugsql/rna_runs.sql
@@ -1,7 +1,7 @@
 -- :name _list-rna-runs :? :*
 SELECT `r`.*,
        `rr`.`r1`, `rr`.`r2`, `rr`.`control-panel`,
-       `rr`.`bam`, `rr`.`fusions`, `rr`.`expressions`, `rr`.`intron-retentions`
+       `rr`.`bam`, `rr`.`fusions`, `rr`.`expressions`, `rr`.`intron-retentions`, `rr`.`svs`
   FROM `rna-runs` AS `rr`
          INNER JOIN `runs` AS `r`
              ON `r`.`run-id` = `rr`.`run-id`
@@ -12,7 +12,7 @@ SELECT `r`.*,
 -- :name _get-rna-run :? :1
 SELECT `r`.*,
        `rr`.`r1`, `rr`.`r2`, `rr`.`control-panel`,
-       `rr`.`bam`, `rr`.`fusions`, `rr`.`expressions`, `rr`.`intron-retentions`
+       `rr`.`bam`, `rr`.`fusions`, `rr`.`expressions`, `rr`.`intron-retentions`, `rr`.`svs`
   FROM `rna-runs` AS `rr`
          INNER JOIN `runs` AS `r`
              ON `r`.`run-id` = `rr`.`run-id`
@@ -27,5 +27,6 @@ UPDATE `rna-runs`
    SET `bam` = :bam,
        `fusions` = :fusions,
        `expressions` = :expressions,
-       `intron-retentions` = :intron-retentions
+       `intron-retentions` = :intron-retentions,
+       `svs` = :svs
  WHERE `run-id` = :run-id;

--- a/resources/migrations/006-add-rna-svs.down.sql
+++ b/resources/migrations/006-add-rna-svs.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `rna-runs` DROP COLUMN `svs`;

--- a/resources/migrations/006-add-rna-svs.up.sql
+++ b/resources/migrations/006-add-rna-svs.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `rna-runs` ADD COLUMN `svs` VARCHAR(1024) DEFAULT NULL AFTER `intron-retentions`;

--- a/src/genomon_api/db/sql.clj
+++ b/src/genomon_api/db/sql.clj
@@ -140,7 +140,8 @@
    [:bam] [:results :bam]
    [:fusions] [:results :fusions]
    [:expressions] [:results :expressions]
-   [:intron-retentions] [:results :intron-retentions]})
+   [:intron-retentions] [:results :intron-retentions]
+   [:svs] [:results :svs]})
 
 (def ^:private parse-rna
   (comp (partial rename-keys-in rna-samples-key)

--- a/src/genomon_api/executor/genomon_pipeline_cloud.clj
+++ b/src/genomon_api/executor/genomon_pipeline_cloud.clj
@@ -37,7 +37,8 @@
   {:bam "star/rna/rna.Aligned.sortedByCoord.out.bam",
    :fusions "fusion/rna/rna.genomonFusion.result.filt.txt",
    :expressions "expression/rna/rna.genomonExpression.result.txt",
-   :intron-retentions "intron_retention/rna/rna.genomonIR.result.txt"})
+   :intron-retentions "intron_retention/rna/rna.genomonIR.result.txt"
+   :svs "sv/rna/rna.genomonSV.result.filt.txt"})
 
 (defn- ->s3 [output-bucket id s]
   (str output-bucket "/" id "/" s))

--- a/src/genomon_api/handler.clj
+++ b/src/genomon_api/handler.clj
@@ -60,7 +60,9 @@
        ["/expressions.tsv" {:name ::rna/expressions,
                             :get ::rna/get-expressions}]
        ["/intron-retentions.tsv" {:name ::rna/intron-retentions,
-                                  :get ::rna/get-intron-retentions}]]]]]])
+                                  :get ::rna/get-intron-retentions}]
+       ["/svs.tsv" {:name ::rna/svs,
+                    :get ::rna/get-svs}]]]]]])
 
 (def ^:private handler-refs
   (let [http-methods #{:get :head :post :put :delete :options :patch}

--- a/src/genomon_api/handler/pipelines/rna.clj
+++ b/src/genomon_api/handler/pipelines/rna.clj
@@ -122,3 +122,8 @@
   (assoc (result-handler opts :intron-retentions)
          :summary "Get a list of intron-retentions in TSV format"
          :swagger {:produces ["text/tab-separated-values"]}))
+
+(defhandler ::get-svs [_ {:keys [db storage] :as opts}]
+  (assoc (result-handler opts :svs)
+         :summary "Get a list of structural variants in TSV format"
+         :swagger {:produces ["text/tab-separated-values"]}))

--- a/src/genomon_api/util/csv.clj
+++ b/src/genomon_api/util/csv.clj
@@ -37,6 +37,7 @@
 (defn gen-rna-input [{:keys [r1 r2 control-panel]}]
   (-> `[[:fastq [["rna" ~r1 ~r2]]]
         ~@(gen-controlpanel-config control-panel)
+        [:sv-detection [["rna" "None" "None"]]]
         [:fusion [~(conj ["rna"] (if (seq control-panel) "control_panel" "None"))]]
         [:expression [["rna"]]]
         [:intron-retention [["rna"]]]

--- a/test/src/genomon_api/db/sql_test.clj
+++ b/test/src/genomon_api/db/sql_test.clj
@@ -137,7 +137,8 @@
             :image-id image-id,
             :container-id container-id,
             :config {},
-            :results {:bam nil, :fusions nil, :expressions nil, :intron-retentions nil}}
+            :results {:bam nil, :fusions nil, :expressions nil,
+                      :intron-retentions nil, :svs nil}}
            (dissoc (db/get-rna-run *db* {:run-id rna-run-id1})
                    :created-at :updated-at)))
     (is (not (nil? (seq (db/list-rna-runs *db* {:limit 10 :offset 0})))))
@@ -148,7 +149,8 @@
                                              :results {:bam "",
                                                        :fusions "",
                                                        :expressions "",
-                                                       :intron-retentions ""}})))
+                                                       :intron-retentions ""
+                                                       :svs ""}})))
     (is (= 1 (db/delete-rna-run *db* {:run-id rna-run-id1})))
     (is (nil? (db/get-rna-run *db* {:run-id rna-run-id1}))))
   (testing "rna-runs with control panel"
@@ -168,7 +170,8 @@
             :image-id image-id,
             :container-id container-id,
             :config {},
-            :results {:bam nil, :fusions nil, :expressions nil, :intron-retentions nil}}
+            :results {:bam nil, :fusions nil, :expressions nil,
+                      :intron-retentions nil, :svs nil}}
            (dissoc (db/get-rna-run *db* {:run-id rna-run-id2})
                    :created-at :updated-at)))
     (is (not (nil? (seq (db/list-rna-runs *db* {:limit 10 :offset 0})))))
@@ -179,6 +182,7 @@
                                              :results {:bam "",
                                                        :fusions "",
                                                        :expressions "",
-                                                       :intron-retentions ""}})))
+                                                       :intron-retentions ""
+                                                       :svs ""}})))
     (is (= 1 (db/delete-rna-run *db* {:run-id rna-run-id2})))
     (is (nil? (db/get-rna-run *db* {:run-id rna-run-id2})))))

--- a/test/src/genomon_api/handler_test.clj
+++ b/test/src/genomon_api/handler_test.clj
@@ -86,7 +86,8 @@
                  :results {:bam (str example-bucket run-id "/tumor.bam"),
                            :fusions (str example-bucket run-id "/fusions.tsv"),
                            :expressions (str example-bucket run-id "/expressions.tsv"),
-                           :intron-retentions (str example-bucket run-id "/intron-retentions.tsv")}}]
+                           :intron-retentions (str example-bucket run-id "/intron-retentions.tsv"),
+                           :svs (str example-bucket run-id "/svs.tsv")}}]
         (async/go
           (async/<! (async/timeout 100))
           (async/>! ch (assoc run :status :started))
@@ -317,7 +318,8 @@
               :results {:bam nil,
                         :fusions nil,
                         :expressions nil,
-                        :intron-retentions nil},
+                        :intron-retentions nil
+                        :svs nil},
               :config config}
              (dissoc run :created-at :updated-at)))
       (loop [i 0]
@@ -334,11 +336,13 @@
       (let [tumor-bam (*handler* (mock/request :get (str "/api/pipelines/rna/runs/" run-id "/tumor.bam")))
             fusions (*handler* (mock/request :get (str "/api/pipelines/rna/runs/" run-id "/fusions.tsv")))
             expressions (*handler* (mock/request :get (str "/api/pipelines/rna/runs/" run-id "/expressions.tsv")))
-            intron-retentions (*handler* (mock/request :get (str "/api/pipelines/rna/runs/" run-id "/intron-retentions.tsv")))]
+            intron-retentions (*handler* (mock/request :get (str "/api/pipelines/rna/runs/" run-id "/intron-retentions.tsv")))
+            svs (*handler* (mock/request :get (str "/api/pipelines/rna/runs/" run-id "/svs.tsv")))]
         (is (= 200 (:status tumor-bam)))
         (is (= 200 (:status fusions)))
         (is (= 200 (:status expressions)))
-        (is (= 200 (:status intron-retentions))))))
+        (is (= 200 (:status intron-retentions)))
+        (is (= 200 (:status svs))))))
   (testing "Start new RNA run with control panel"
     (let [{post-status :status
            {:keys [run-id]}
@@ -364,6 +368,7 @@
               :results {:bam nil,
                         :fusions nil,
                         :expressions nil,
-                        :intron-retentions nil},
+                        :intron-retentions nil,
+                        :svs nil},
               :config config}
              (dissoc run :created-at :updated-at))))))

--- a/test/src/genomon_api/util/csv_test.clj
+++ b/test/src/genomon_api/util/csv_test.clj
@@ -87,6 +87,9 @@ normal"
     "[fastq]
 rna,r1.fastq,r2.fastq
 
+[sv_detection]
+rna,None,None
+
 [fusion]
 rna,None
 
@@ -108,6 +111,9 @@ control_sample0,sample1.bam
 
 [controlpanel]
 control_panel,control_sample0
+
+[sv_detection]
+rna,None,None
 
 [fusion]
 rna,control_panel


### PR DESCRIPTION
This PR enables the [`sv-in-rna`](https://github.com/chrovis/genomon_pipeline_cloud/tree/feature/sv-in-rna) feature of `genomon_pipeline_cloud`.

Concretely, the following changes have been made:

- Set up Genomon's parameters necessary for sv (fd1ffa4)
- Modified `genomon-api.util.csv` so that it generates the `[sv_detection]` section for Genomon CSV (da85445)
- Added a new column `svs` into the `rna-runs` table to store the sv result (73a187d)
- Added an API endpoint to download RNA SV files (682f047)