### PR TITLE
Control panel support for sv-in-rna

### DIFF
--- a/src/genomon_api/util/csv.clj
+++ b/src/genomon_api/util/csv.clj
@@ -37,8 +37,10 @@
 (defn gen-rna-input [{:keys [r1 r2 control-panel]}]
   (-> `[[:fastq [["rna" ~r1 ~r2]]]
         ~@(gen-controlpanel-config control-panel)
-        [:sv-detection [["rna" "None" "None"]]]
-        [:fusion [~(conj ["rna"] (if (seq control-panel) "control_panel" "None"))]]
+        [:sv-detection
+         [["rna" "None" ~(if (seq control-panel) "control_panel" "None")]]]
+        [:fusion
+         [["rna" ~(if (seq control-panel) "control_panel" "None")]]]
         [:expression [["rna"]]]
         [:intron-retention [["rna"]]]
         [:qc [["rna"]]]]

--- a/test/src/genomon_api/util/csv_test.clj
+++ b/test/src/genomon_api/util/csv_test.clj
@@ -113,7 +113,7 @@ control_sample0,sample1.bam
 control_panel,control_sample0
 
 [sv_detection]
-rna,None,None
+rna,None,control_panel
 
 [fusion]
 rna,control_panel


### PR DESCRIPTION
#5 added the support for sv-in-rna. This PR adds further support for it, especially on analysis with control panel enabled. To be concrete, it just modifies the  Genomon CSV generator so that it generates the control panel configuration for the `[sv_detection]` section.

I've confirmed, with some samples, that `genomon-api` successfully ran the RNA pipeline with control panel, and the result included the SV artifacts.

Note that if you want to get `genomon-api` to work with this patch applied, make sure you have `genomon_pipeline_cloud` patched with [PR #1](https://github.com/chrovis/genomon_pipeline_cloud/pull/1) on your environment.