### PR TITLE
Allow star aligner to accept fastq.gz samples

### DIFF
--- a/resources/genomon_api/rna_param.edn
+++ b/resources/genomon_api/rna_param.edn
@@ -25,7 +25,7 @@
  {:resource "--aws-ec2-instance-type t2.2xlarge --disk-size 128",
   :image "genomon/star_alignment",
   :bamtofastq-option "collate=1 combs=1 exclude=QCFAIL,SECONDARY,SUPPLEMENTARY tryoq=1",
-  :star-option "--runThreadN 6 --outSAMstrandField intronMotif --outSAMunmapped Within --alignMatesGapMax 500000 --alignIntronMax 500000 --alignSJstitchMismatchNmax -1 -1 -1 -1 --outSJfilterDistToOtherSJmin 0 0 0 0 --outSJfilterOverhangMin 12 12 12 12 --outSJfilterCountUniqueMin 1 1 1 1 --outSJfilterCountTotalMin 1 1 1 1 --chimSegmentMin 12 --chimJunctionOverhangMin 12 --outSAMtype BAM Unsorted",
+  :star-option "--runThreadN 6 --readFilesCommand \\\"zcat -f\\\" --outSAMstrandField intronMotif --outSAMunmapped Within --alignMatesGapMax 500000 --alignIntronMax 500000 --alignSJstitchMismatchNmax -1 -1 -1 -1 --outSJfilterDistToOtherSJmin 0 0 0 0 --outSJfilterOverhangMin 12 12 12 12 --outSJfilterCountUniqueMin 1 1 1 1 --outSJfilterCountTotalMin 1 1 1 1 --chimSegmentMin 12 --chimJunctionOverhangMin 12 --outSAMtype BAM Unsorted",
   :star-reference "s3://genomon-bucket-xcoo-archive-202001/_GRCh37/reference/GRCh37.STAR-2.5.2a",
   :samtools-sort-option "-@ 6 -m 3G"},
  :fusion-count-control


### PR DESCRIPTION
Currently, the RNA pipeline only accepts `.fastq` samples. This PR makes it accept `.fastq.gz` as well as `.fastq`.

The essential change is just to feed the `--readFilesCommand "zcat -f"` option to the `star` aligner.
`genomon-api` then generates `.ini` that looks like:

```ini
[star_alignment]
...
star_option = --runThreadN 6 --readFilesCommand \"zcat -f\" --outSAMstrandField intronMotif ...
...
```

And `genomon_pipeline_cloud`, in turn, generates a script that contains a line like:

```sh
export STAR_OPTION="--runThreadN 6 --readFilesCommand \"zcat -f\" --outSAMstrandField intronMotif ..."
```

I thought `--readFilesCommand 'zcat -f'` (i.e. using `'`s instead of these tricky `\\\"`s) could also work, but it ended up in failure for some reason when I tried once.